### PR TITLE
Feature/one time login

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,7 @@
   "description": "Vactory is a custom Drupal profile which is developed and released by VOID Agency.",
   "type": "drupal-profile",
   "license": "GPL-2.0-or-later",
-  "authors": [
-  ],
+  "authors": [],
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
@@ -90,7 +89,7 @@
     "drupal/minifyhtml": "^1.8",
     "drupal/flag": "^4.0@beta",
     "drupal/rate": "^1.0",
-    "masterminds/html5":"2.3.0",
+    "masterminds/html5": "2.3.0",
     "drupal/link_attributes": "^1.9",
     "drupal/entity_embed": "^1.0",
     "drupal/search_api_autocomplete": "^1.4",
@@ -233,6 +232,9 @@
       },
       "drupal/email_registration": {
         "Allow authentication via mail and password over OAuth2 module": "https://www.drupal.org/files/issues/2021-10-06/2991141-19-allow_authentication_via_mail.patch"
+      },
+      "drupal/simple_oauth": {
+        "Auth revoke on profile update": "https://www.drupal.org/files/issues/2019-04-15/simple_oauth-auth-revoke-2946882-34.patch"
       }
     }
   },

--- a/modules/vactory_decoupled/src/Controller/OneTimeToken.php
+++ b/modules/vactory_decoupled/src/Controller/OneTimeToken.php
@@ -22,6 +22,7 @@ use Drupal\simple_oauth\Entities\ClientEntity;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Drupal\user\UserStorageInterface;
+use Defuse\Crypto\Core;
 
 class OneTimeToken extends ControllerBase {
 
@@ -200,6 +201,8 @@ class OneTimeToken extends ControllerBase {
       NULL,
       Settings::get('simple_oauth.key_permissions_check', TRUE)
     );
+    $salt = Settings::getHashSalt();
+    $encryptionKey = Core::ourSubstr($salt, 0, 32);
 
     $grant = new PasswordGrant($this->userRepository, $this->refreshTokenRepository);
     $grant->setAccessTokenRepository($this->accessTokenRepository);
@@ -226,8 +229,7 @@ class OneTimeToken extends ControllerBase {
 
     $responseType = new BearerTokenResponse();
     $responseType->setPrivateKey($crypt_key);
-    // This is needed by the auth server but not used.
-    $responseType->setEncryptionKey(\base64_encode(\random_bytes(36)));
+    $responseType->setEncryptionKey($encryptionKey);
 
     $responseType->setAccessToken($accessToken);
     $responseType->setRefreshToken($refreshToken);

--- a/modules/vactory_decoupled/src/Controller/OneTimeToken.php
+++ b/modules/vactory_decoupled/src/Controller/OneTimeToken.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Drupal\vactory_decoupled\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+// use Symfony\Component\HttpFoundation\Response;
+use League\OAuth2\Server\Grant\PasswordGrant;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
+use League\OAuth2\Server\Repositories\UserRepositoryInterface;
+use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
+use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use League\OAuth2\Server\CryptKey;
+use Drupal\Core\Site\Settings;
+use Drupal\Core\File\FileSystemInterface;
+use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
+use GuzzleHttp\Psr7\Response;
+
+
+class OneTimeToken extends ControllerBase {
+
+  /**
+   * @var \League\OAuth2\Server\Repositories\UserRepositoryInterface
+   */
+  protected $userRepository;
+
+  /**
+   * @var \League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface
+   */
+  protected $refreshTokenRepository;
+
+  /**
+   * @var \League\OAuth2\Server\Repositories\ClientRepositoryInterface
+   */
+  protected $clientRepository;
+
+  /**
+   * @var \League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface
+   */
+  protected $accessTokenRepository;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * @var string
+   */
+  protected $privateKeyPath;
+
+  /**
+   * The file system.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(
+    UserRepositoryInterface $user_repository,
+    AccessTokenRepositoryInterface $access_token_repository,
+    RefreshTokenRepositoryInterface $refresh_token_repository,
+    ClientRepositoryInterface $client_repository,
+    ConfigFactoryInterface $config_factory)
+  {
+    $this->userRepository = $user_repository;
+    $this->refreshTokenRepository = $refresh_token_repository;
+    $this->clientRepository = $client_repository;
+    $this->accessTokenRepository = $access_token_repository;
+    $this->configFactory = $config_factory;
+    $settings = $config_factory->get('simple_oauth.settings');
+    $this->setKeyPaths($settings);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container)
+  {
+    return new static(
+      $container->get('simple_oauth.repositories.user'),
+      $container->get('simple_oauth.repositories.access_token'),
+      $container->get('simple_oauth.repositories.refresh_token'),
+      $container->get('simple_oauth.repositories.client'),
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * Processes POST requests to /oauth/one-time-token.
+   */
+  public function token() {
+    // Initialize the crypto key, optionally disabling the permissions check.
+    $crypt_key = new CryptKey(
+      $this->fileSystem()->realpath($this->privateKeyPath),
+      NULL,
+      Settings::get('simple_oauth.key_permissions_check', TRUE)
+    );
+
+    $grant = new PasswordGrant($this->userRepository, $this->refreshTokenRepository);
+    $grant->setAccessTokenRepository($this->accessTokenRepository);
+    $grant->setPrivateKey($crypt_key);
+    $settings = $this->configFactory->get('simple_oauth.settings');
+    $accessTokenTTL = new \DateInterval(sprintf('PT%dS', $settings->get('refresh_token_expiration')));
+    // @todo: client ID
+    $client = $this->clientRepository->getClientEntity("3087e3a0-0833-4ba3-8e47-c14d3fc7d19f");
+
+    $abstractGrantReflection = new \ReflectionClass($grant);
+    $issueAccessTokenMethod = $abstractGrantReflection->getMethod('issueAccessToken');
+    $issueAccessTokenMethod->setAccessible(true);
+
+    // @todo: make sure to get hash, timestamp & uid, and try to load the user.
+    $accessToken = $issueAccessTokenMethod->invoke(
+      $grant,
+      $accessTokenTTL,
+      $client,
+      1,
+      []
+    );
+
+    $issueRefreshTokenMethod = $abstractGrantReflection->getMethod('issueRefreshToken');
+    $issueRefreshTokenMethod->setAccessible(true);
+    $refreshToken = $issueRefreshTokenMethod->invoke($grant, $accessToken);
+
+    $responseType = new BearerTokenResponse();
+    $responseType->setPrivateKey($crypt_key);
+    $responseType->setEncryptionKey(\base64_encode(\random_bytes(36))); // @todo: a big no for this
+
+    $responseType->setAccessToken($accessToken);
+    $responseType->setRefreshToken($refreshToken);
+    $response = $responseType->generateHttpResponse(new Response());
+    return $response;
+  }
+
+  /**
+   * Set the public and private key paths.
+   *
+   * @param \Drupal\Core\Config\ImmutableConfig $settings
+   *   The Simple OAuth settings configuration object.
+   */
+  protected function setKeyPaths(ImmutableConfig $settings)
+  {
+    // $this->publicKeyPath = $settings->get('public_key');
+    $this->privateKeyPath = $settings->get('private_key');
+  }
+
+  /**
+   * Lazy loads the file system.
+   *
+   * @return \Drupal\Core\File\FileSystemInterface
+   *   The file system service.
+   */
+  protected function fileSystem(): FileSystemInterface
+  {
+    if (!isset($this->fileSystem)) {
+      $this->fileSystem = \Drupal::service('file_system');
+    }
+    return $this->fileSystem;
+  }
+
+}

--- a/modules/vactory_decoupled/src/Plugin/Field/InternalNodeEntityExtraFieldItemList.php
+++ b/modules/vactory_decoupled/src/Plugin/Field/InternalNodeEntityExtraFieldItemList.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\vactory_decoupled\Plugin\Field;
+
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\TypedData\ComputedItemListTrait;
+use Drupal\node\Entity\Node;
+use Drupal\Core\Url;
+
+/**
+ * Extra data per node.
+ */
+class InternalNodeEntityExtraFieldItemList extends FieldItemList
+{
+
+  use ComputedItemListTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function computeValue()
+  {
+    /** @var Node $entity */
+    $entity = $this->getEntity();
+    $entity_type = $entity->getEntityTypeId();
+
+    if (!in_array($entity_type, ['node'])) {
+      return;
+    }
+
+    if ($entity->isNew()) {
+      return;
+    }
+
+    $value = [
+      'translations' => $this->getTranslations($entity),
+    ];
+
+
+    $this->list[0] = $this->createItem(0, $value);
+  }
+
+  protected function getTranslations($entity)
+  {
+    $siteConfig = \Drupal::config('system.site');
+    $front_uri = $siteConfig->get('page.front');
+    $internal_uri = "/node/" . $entity->id();
+
+    $langcodes = \Drupal::languageManager()->getLanguages();
+    $langcodesList = array_keys($langcodes);
+    $data = [];
+
+    // Frontpage special case.
+    if ($front_uri === $internal_uri) {
+      foreach ($langcodesList as $langcode) {
+        $data[$langcode] =
+        Url::fromRoute('<front>', [], [
+          'language' => \Drupal::languageManager()->getLanguage($langcode),
+        ])->toString();
+      }
+    }
+    else {
+      foreach ($langcodesList as $langcode) {
+        if ($entity->hasTranslation($langcode)) {
+          $translation = \Drupal::service('entity.repository')->getTranslationFromContext($entity, $langcode);
+          $data[$langcode] =
+            $translation->toUrl('canonical', [
+              'language' => $translation->language(),
+            ])->toString();
+        }
+        else {
+          $data[$langcode] = "/" . $langcode . "/node/" . $entity->id();
+        }
+
+      }
+    }
+
+    return $data;
+  }
+}

--- a/modules/vactory_decoupled/src/Plugin/Validation/Constraint/SspaProtectedUserFieldConstraint.php
+++ b/modules/vactory_decoupled/src/Plugin/Validation/Constraint/SspaProtectedUserFieldConstraint.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\vactory_decoupled\Plugin\Validation\Constraint;
+
+use Drupal\user\Plugin\Validation\Constraint\ProtectedUserFieldConstraint;
+
+/**
+ * Checks if the plain text password is provided for editing a protected field.
+ *
+ * @Constraint(
+ *   id = "SspaProtectedUserField",
+ *   label = @Translation("Password required for protected field change", context = "Validation")
+ * )
+ */
+class SspaProtectedUserFieldConstraint extends ProtectedUserFieldConstraint {
+
+}

--- a/modules/vactory_decoupled/src/Plugin/Validation/Constraint/SspaProtectedUserFieldConstraintValidator.php
+++ b/modules/vactory_decoupled/src/Plugin/Validation/Constraint/SspaProtectedUserFieldConstraintValidator.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\vactory_decoupled\Plugin\Validation\Constraint;
+
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\user\Plugin\Validation\Constraint\ProtectedUserFieldConstraintValidator;
+use Drupal\user\UserStorageInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Decorates the ProtectedUserFieldConstraint constraint.
+ */
+class SspaProtectedUserFieldConstraintValidator extends ProtectedUserFieldConstraintValidator {
+
+  /**
+   * Whether or not restricted password managment is enabled.
+   *
+   * @var bool
+   */
+  protected $restrictedPasswordManagement = TRUE; // @todo: setting for this
+
+  /**
+   * Constructs the object.
+   *
+   * @param \Drupal\user\UserStorageInterface $user_storage
+   *   The user storage handler.
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   The current user.
+   * @param \Drupal\externalauth\AuthmapInterface $authmap
+   */
+  public function __construct(UserStorageInterface $user_storage, AccountProxyInterface $current_user) {
+    parent::__construct($user_storage, $current_user);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')->getStorage('user'),
+      $container->get('current_user'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($items, Constraint $constraint) {
+    if (!isset($items)) {
+      return;
+    }
+
+    /** @var \Drupal\Core\Field\FieldItemListInterface $items */
+    $field = $items->getFieldDefinition();
+
+    /** @var \Drupal\user\UserInterface $account */
+    $account = $items->getEntity();
+    if (!isset($account) || !empty($account->_skipProtectedUserFieldConstraint)) {
+      // Looks like we are validating a field not being part of a user, or the
+      // constraint should be skipped, so do nothing.
+      return;
+    }
+
+    // Only validate for existing entities and if this is the current user.
+    if (!$account->isNew() && $account->id() == $this->currentUser->id()) {
+      if ($field->getName() === 'mail') {
+        return;
+      }
+    }
+
+    parent::validate($items, $constraint);
+  }
+
+}

--- a/modules/vactory_decoupled/vactory_decoupled.install
+++ b/modules/vactory_decoupled/vactory_decoupled.install
@@ -10,7 +10,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 /**
  * Add node_settings field.
  */
-function vactory_decoupled_update_9001() {
+function vactory_decoupled_update_9001()
+{
   $storage_definition = BaseFieldDefinition::create('string_long')
     ->setLabel(t('Node Settings'))
     ->setDescription(t('Add extra parameters in JSON Format : { "isHomePage": true, "taxonomy": 4, "limit": 6 }'))
@@ -30,4 +31,24 @@ function vactory_decoupled_update_9001() {
 
   \Drupal::entityDefinitionUpdateManager()
     ->installFieldStorageDefinition('node_settings', 'node', 'node', $storage_definition);
+}
+
+/**
+ * Add internal_extra field.
+ */
+function vactory_decoupled_update_9002()
+{
+  $storage_definition = BaseFieldDefinition::create('map')
+    ->setLabel(t('Node extra'))
+    ->setDescription(t('Extra data per node'))
+    ->setTranslatable(FALSE)
+    ->setClass('\Drupal\vactory_decoupled\Plugin\Field\InternalNodeEntityExtraFieldItemList')
+    ->setComputed(TRUE)
+    ->setReadOnly(TRUE)
+    ->setTargetEntityTypeId('node')
+    ->setDisplayConfigurable('form', FALSE)
+    ->setDisplayConfigurable('view', FALSE);
+
+  \Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('internal_extra', 'node', 'node', $storage_definition);
 }

--- a/modules/vactory_decoupled/vactory_decoupled.module
+++ b/modules/vactory_decoupled/vactory_decoupled.module
@@ -17,6 +17,7 @@ use Drupal\user\UserInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Drupal\simple_oauth\Entities\AccessTokenEntity;
 use Drupal\user\Entity\User;
+use Drupal\Component\Render\PlainTextOutput;
 
 /**
  * Implements hook_form_BASE_FORM_ID_alter().
@@ -339,3 +340,59 @@ function _auth_make_unitials_from_single_word($name)
   }
   return strtoupper(substr($name, 0, 2));
 }
+
+/**
+ * Implements hook_mail_alter().
+ */
+function vactory_decoupled_mail_alter(&$message) {
+  if ($message['id'] === 'user_password_reset') {
+    $key = 'password_reset';
+    $variables = ['user' => $message['params']['account']];
+    $token_service = \Drupal::token();
+    $language_manager = \Drupal::languageManager();
+    $langcode = $message['langcode'];
+    $language = $language_manager->getLanguage($langcode);
+    $original_language = $language_manager->getConfigOverrideLanguage();
+    $language_manager->setConfigOverrideLanguage($language);
+    $mail_config = \Drupal::config('user.mail');
+    $token_options = ['langcode' => $langcode, 'callback' => '_vactory_decoupled_user_mail_tokens', 'clear' => TRUE];
+    $message['subject'] = '';
+    $message['body'] = [];
+    $message['subject'] .= PlainTextOutput::renderFromHtml($token_service->replace($mail_config->get($key . '.subject'), $variables, $token_options));
+    $message['body'][] = $token_service->replace($mail_config->get($key . '.body'), $variables, $token_options);
+    $language_manager->setConfigOverrideLanguage($original_language);
+  }
+}
+
+/**
+ * @param $replacements
+ * @param $data
+ * @param $options
+ */
+function _vactory_decoupled_user_mail_tokens(&$replacements, $data, $options) {
+  if (isset($data['user'])) {
+    $replacements['[user:one-time-login-url]'] = _vactory_decoupled_user_pass_reset_url($data['user'], $options);
+    $replacements['[user:cancel-url]'] = user_cancel_url($data['user'], $options);
+  }
+}
+
+/**
+ * @param $account
+ * @param array $options
+ *
+ * @return string
+ */
+function _vactory_decoupled_user_pass_reset_url($account, $options = []) {
+  $frontend_url = Settings::get('FRONTEND_URL', "http://localhost:3000");
+  $timestamp = \Drupal::time()->getRequestTime();
+  $langcode = $options['langcode'] ?? $account->getPreferredLangcode();
+  $data = [
+    'uid' => $account->id(),
+    'timestamp' => $timestamp,
+    'hash' => user_pass_rehash($account, $timestamp),
+  ];
+
+  $query_string = http_build_query($data, "", "&", PHP_QUERY_RFC3986);
+  return $frontend_url . "/$langcode/user/one-time-login?" . $query_string;
+}
+

--- a/modules/vactory_decoupled/vactory_decoupled.module
+++ b/modules/vactory_decoupled/vactory_decoupled.module
@@ -184,14 +184,19 @@ function vactory_decoupled_entity_base_field_info(EntityTypeInterface $entity_ty
       ->setComputed(TRUE)
       ->setReadOnly(TRUE)
       ->setTargetEntityTypeId($entity_type->id())
-//      ->setDisplayOptions('view', [
-//        'label' => 'hidden',
-//        'type' => 'hidden',
-//        'weight' => 0,
-//      ])
-//      ->setDisplayOptions('form', ['type' => 'hidden'])
-//      ->setDisplayConfigurable('form', TRUE)
-//      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', FALSE)
+      ->setDisplayConfigurable('view', FALSE);
+  }
+
+  if ($entity_type->id() === 'node') {
+    $fields['internal_extra'] = BaseFieldDefinition::create('map')
+    ->setLabel(t('Node extra'))
+    ->setDescription(t('Extra data per node'))
+    ->setTranslatable(FALSE)
+      ->setClass('\Drupal\vactory_decoupled\Plugin\Field\InternalNodeEntityExtraFieldItemList')
+      ->setComputed(TRUE)
+      ->setReadOnly(TRUE)
+      ->setTargetEntityTypeId($entity_type->id())
       ->setDisplayConfigurable('form', FALSE)
       ->setDisplayConfigurable('view', FALSE);
   }

--- a/modules/vactory_decoupled/vactory_decoupled.module
+++ b/modules/vactory_decoupled/vactory_decoupled.module
@@ -366,7 +366,8 @@ function vactory_decoupled_mail_alter(&$message) {
     $message['subject'] = '';
     $message['body'] = [];
     $message['subject'] .= PlainTextOutput::renderFromHtml($token_service->replace($mail_config->get($key . '.subject'), $variables, $token_options));
-    $message['body'][] = $token_service->replace($mail_config->get($key . '.body'), $variables, $token_options);
+    $markup = ['#markup' => $token_service->replace($mail_config->get($key . '.body'), $variables, $token_options)];
+    $message['body'][] = \Drupal::service('renderer')->render($markup);
     $language_manager->setConfigOverrideLanguage($original_language);
   }
 }
@@ -392,7 +393,8 @@ function _vactory_decoupled_user_mail_tokens(&$replacements, $data, $options) {
 function _vactory_decoupled_user_pass_reset_url($account, $options = []) {
   $frontend_url = Settings::get('FRONTEND_URL', "http://localhost:3000");
   $timestamp = \Drupal::time()->getRequestTime();
-  $langcode = $options['langcode'] ?? $account->getPreferredLangcode();
+  $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+  $langcode = $language ?? $account->getPreferredLangcode();
   $data = [
     'uid' => $account->id(),
     'timestamp' => $timestamp,

--- a/modules/vactory_decoupled/vactory_decoupled.module
+++ b/modules/vactory_decoupled/vactory_decoupled.module
@@ -262,6 +262,9 @@ function vactory_decoupled_entity_type_alter(array &$entity_types) {
  * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
  */
 function get_oauth_user_infos(UserInterface $user) {
+  /** @var \Drupal\Core\File\FileUrlGeneratorInterface $file_url_generator */
+  $file_url_generator = \Drupal::service('file_url_generator');
+
   $full_name = $user->getDisplayName();
   $first_name = $user->get('field_first_name')->getString();
   $last_name = $user->get('field_last_name')->getString();
@@ -274,7 +277,11 @@ function get_oauth_user_infos(UserInterface $user) {
   if (user_picture_enabled() && !$user->get('user_picture')->isEmpty()) {
     $pictureUri = $user->get('user_picture')->entity->getFileUri();
     $style = \Drupal::entityTypeManager()->getStorage('image_style')->load('avatar');
-    $avatar = $style->buildUrl($pictureUri);
+    $derivative_uri = $style->buildUri($pictureUri);
+    $avatar = $file_url_generator->generateAbsoluteString($style->buildUrl($pictureUri));
+    if (!file_exists($derivative_uri)) {
+      $style->createDerivative($pictureUri, $derivative_uri);
+    }
   }
 
   return [

--- a/modules/vactory_decoupled/vactory_decoupled.module
+++ b/modules/vactory_decoupled/vactory_decoupled.module
@@ -405,3 +405,12 @@ function _vactory_decoupled_user_pass_reset_url($account, $options = []) {
   return $frontend_url . "/$langcode/user/one-time-login?" . $query_string;
 }
 
+/**
+ * Implements hook_validation_constraint_alter().
+ *
+ * Replace core's ProtectedUserFieldConstraint with a decorated version that
+ * skips over the validation if restricted password mangement is enabled.
+ */
+function vactory_decoupled_validation_constraint_alter(array &$definitions) {
+  $definitions['ProtectedUserField']['class'] = 'Drupal\vactory_decoupled\Plugin\Validation\Constraint\SspaProtectedUserFieldConstraint';
+}

--- a/modules/vactory_decoupled/vactory_decoupled.routing.yml
+++ b/modules/vactory_decoupled/vactory_decoupled.routing.yml
@@ -101,3 +101,11 @@ vactory_decoupled.get_unique_username_by_email:
   methods: [GET]
   requirements:
     _permission: 'access content'
+
+vactory_decoupled.one_time_token:
+  path: '/oauth/one-time-token'
+  defaults:
+    _controller: 'Drupal\vactory_decoupled\Controller\OneTimeToken::token'
+  methods: [POST]
+  requirements:
+    _access: 'TRUE'


### PR DESCRIPTION
- New endpoint for generating one-time-login links available at `/oauth/one-time-token`, mostly used for reset password by Next.js.
- Patch for `simple_oauth` https://www.drupal.org/project/simple_oauth/issues/2946882
- Fix for avatar, we are now enforcing it generation upon request, Next.js Image component was having troubles accessing the image once the user updated his profile picture.
- Introduced some custom validation constraints for updating user profile, mostly email which required the current password to be able to change it. It would be better if we could validate that new email but for now we just skip it and assume the user is the owner.
- Added an extra field for node entity, this will hold extra data without the need to another field each time - require a `drush updb`.