### PR TITLE
Fix: (vactory_decoupled_revalidator) generate url only if the entity …

### DIFF
--- a/modules/vactory_decoupled/modules/vactory_decoupled_revalidator/src/Event/EntityRevalidateEvent.php
+++ b/modules/vactory_decoupled/modules/vactory_decoupled_revalidator/src/Event/EntityRevalidateEvent.php
@@ -53,7 +53,7 @@ class EntityRevalidateEvent extends Event implements EntityRevalidateEventInterf
    * @throws \Drupal\Core\Entity\EntityMalformedException
    */
   public static function createFromEntity(EntityInterface $entity, string $action): self {
-    $url = $entity->hasLinkTemplate('canonical') ? $entity->toUrl()
+    $url = $entity->id() && $entity->hasLinkTemplate('canonical') ? $entity->toUrl()
       ->toString(TRUE)
       ->getGeneratedUrl() : NULL;
     return new static($entity, $action, $url);


### PR DESCRIPTION
…has an id