### PR TITLE
Add: #52129 attribute field label to url_extended

### DIFF
--- a/modules/vactory_content_package/src/Form/DynamicFieldJsonGenerator.php
+++ b/modules/vactory_content_package/src/Form/DynamicFieldJsonGenerator.php
@@ -94,6 +94,7 @@ class DynamicFieldJsonGenerator extends ModalForm {
           'title' => $this->getDummyData('text'),
           'url' => $this->getDummyData('url'),
           'attributes' => [
+            'label' => '',
             'class' => '',
             'id' => 'link-' . uniqid(),
             'target' => '_self',

--- a/modules/vactory_content_package/src/Services/ContentPackageImportManager.php
+++ b/modules/vactory_content_package/src/Services/ContentPackageImportManager.php
@@ -420,6 +420,7 @@ class ContentPackageImportManager implements ContentPackageImportManagerInterfac
             "title" => "Live Market",
             "url" => "/mode/1",
             "attributes" => [
+              "label" => "",
               "class" => "",
               "id" => "cta-mde3mdk4mzc4mju",
               "target" => "_self",

--- a/modules/vactory_dynamic_field/src/Element/UrlExtendedElement.php
+++ b/modules/vactory_dynamic_field/src/Element/UrlExtendedElement.php
@@ -79,6 +79,11 @@ class UrlExtendedElement extends FormElement {
       '#type' => 'details',
       '#title' => t('Link attributes'),
     ];
+    $element['attributes']['label'] = [
+      '#type' => 'textfield',
+      '#title' => t('Link Label'),
+      '#default_value' => isset($default_values['attributes']['label']) ? $default_values['attributes']['label'] : '',
+    ];
     $element['attributes']['class'] = [
       '#type' => 'textfield',
       '#title' => t('Link classes'),


### PR DESCRIPTION
**Added a New Field 'label' to URL Extended Field for Accessibility**

This pull request introduces a new field 'label' in the attribute section of the URL extended field. The addition aims to enhance accessibility.

Changes:

- Added a new 'label' field in the attribute section of the URL extended field.
- Updated vactory_content_package to adjust to the new structure of the URL extended field.
