### PR TITLE
fix: handle ConnectException on cache clear

### DIFF
--- a/modules/vactory_decoupled/vactory_decoupled.module
+++ b/modules/vactory_decoupled/vactory_decoupled.module
@@ -30,6 +30,7 @@ use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Component\Utility\UrlHelper;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Exception\ConnectException;
 use Drupal\menu_item_extras\Entity\MenuItemExtrasMenuLinkContent;
 
 /**
@@ -852,6 +853,11 @@ function clear_next_cache($query = []) {
     return FALSE;
   }
   catch (RequestException $e) {
+    \Drupal::logger('clear_next_cache')->warning($error_msg);
+    \Drupal::logger('clear_next_cache')->warning($e->getMessage());
+    return FALSE;
+  }
+  catch (ConnectException $e) {
     \Drupal::logger('clear_next_cache')->warning($error_msg);
     \Drupal::logger('clear_next_cache')->warning($e->getMessage());
     return FALSE;


### PR DESCRIPTION
drupal Install crash when it try to clear cache and doesn't find a frontend instance to connect to