### PR TITLE
feat: #59861 - prevent notifications sms/mail outside production

### DIFF
--- a/modules/vactory_core/vactory_core.module
+++ b/modules/vactory_core/vactory_core.module
@@ -141,6 +141,19 @@ function vactory_core_mailer_build(EmailInterface $email) {
   // When vactory_mail_redirect is defined.
   $route_name = Drupal::routeMatch()->getRouteName();
   $mail_redirect = Settings::get('vactory_mail_redirect', '');
+  // Check if the site is in production.
+  $is_production = file_exists('/etc/machine-id');
+  if (!$is_production && empty($mail_redirect)) {
+    $email->setTo([]);
+    $email->setCc([]);
+    $email->setBcc([]);
+    if (!$is_production) {
+      \Drupal::logger('vactory_mail_security')->info('Production environment detected, the mail was not sent');
+    }
+    if (empty($mail_redirect)) {
+      \Drupal::logger('vactory_mail_security')->info('No mail redirect defined, you need to define it in the settings.php file');
+    }
+  }
   if ($mail_redirect && !empty($mail_redirect) && $route_name !== 'user.pass') {
     if (!is_array($mail_redirect)) {
       $mail_redirect = array_map('trim', explode(',', $mail_redirect));

--- a/modules/vactory_otp/src/Services/VactoryOtpService.php
+++ b/modules/vactory_otp/src/Services/VactoryOtpService.php
@@ -11,6 +11,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Utility\Token;
 use Drupal\vactory_sms_sender\Services\VactorySmsSenderService;
+use Drupal\Core\Site\Settings;
 
 /**
  * Contains otp senders (sms, mail).
@@ -203,6 +204,15 @@ class VactoryOtpService {
     $api_key = $config->get('api_key');
     $url = $config->get('url');
     $client = \Drupal::httpClient();
+    
+    // Get the vactory_enable_sms setting from settings.php.
+    $vactory_sms_enabled = Settings::get('vactory_enable_sms', '');
+    // Check if the machine is in production.
+    $is_production = file_exists('/etc/machine-id');
+    // If not production and vactory_sms_enabled is false, do not send SMS.
+    if (!$is_production && empty($vactory_sms_enabled)) {
+      return FALSE;
+    }
 
     if ($last = $this->store->get('last_sms_otp_sent')) {
       $cd = $config->get('cooldown');

--- a/modules/vactory_sms_sender/src/Services/VactorySmsSenderService.php
+++ b/modules/vactory_sms_sender/src/Services/VactorySmsSenderService.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\vactory_sms_sender\Services;
 
+use Drupal\Core\Site\Settings;
+
 /**
  * Vactory SMS Sender Service.
  */
@@ -27,6 +29,24 @@ class VactorySmsSenderService {
     $basic_auth_password = $config->get('basic_auth_password');
     $api_content_type = $config->get('api_content_type');
     $data_keys = $config->get('data_keys');
+    
+    // Get the vactory_enable_sms setting from settings.php.
+    $vactory_sms_enabled = Settings::get('vactory_enable_sms', '');
+    // Check if the machine is in production.
+    $is_production = file_exists('/etc/machine-id');
+
+    // If not production and vactory_sms_enabled is false, do not send SMS.
+    if (!$is_production && empty($vactory_sms_enabled)) {
+      if (!$is_production) {
+        \Drupal::logger('vactory_sms_sender')
+          ->info("SMS sending skipped: Production environment detected, the sms was not sent");
+      }
+      if (empty($vactory_sms_enabled)) {
+        \Drupal::logger('vactory_sms_sender')
+          ->info("SMS sending skipped: vactory_sms_enabled is not defined in settings.php");
+      }
+      return FALSE;
+    }
 
     // Prepare Authorization part.
     if ($authorization === 'api_key') {


### PR DESCRIPTION
**Le fichier /etc/machine-id est utilisé comme indicateur d’environnement de production.**
`$is_production = file_exists('/etc/machine-id');`
- Présence du fichier → Le site est considéré comme étant en production.
- Absence du fichier → Le site est considéré comme étant en développement ou préproduction.

**La variable vactory_mail_redirect permet de définir une adresse e-mail de redirection dans les environnements hors production.**
- Si elle est configurée → Tous les e-mails envoyés par le site sont redirigés vers cette adresse unique.
- Si elle est absente ou vide → Les e-mails sont bloqués (destinataires vidés).

**La variable vactory_enable_sms est définie dans le fichier settings.php et permet de contrôler l’envoi de SMS.**
Si activée (true) → Les SMS peuvent être envoyés même en environnement hors production.
Si désactivée (vide ou false) → Les SMS ne seront pas envoyés hors production.