### PR TITLE
fix: #65597 - remote_video and file fields empty when editing inside …

### DIFF
--- a/modules/vactory_dynamic_field/src/Form/ModalForm.php
+++ b/modules/vactory_dynamic_field/src/Form/ModalForm.php
@@ -572,7 +572,7 @@ class ModalForm extends FormBase {
               ];
             }
 
-            if ($element_type == 'image') {
+            if ($element_type == 'image' || $element_type == 'file' || $element_type == 'remote_video') {
               // Restore parent for other fields.
               $form['#parents'] = $form_parents;
             }


### PR DESCRIPTION
…grouped template fields